### PR TITLE
ScoreManager 현상금 점수 보너스 구현

### DIFF
--- a/Assets/01_Scenes/PlayerTestScene.unity
+++ b/Assets/01_Scenes/PlayerTestScene.unity
@@ -1380,6 +1380,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d608b487600b49448b669005b18d140, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  playerHp: 0
+  playerMaxHp: 0
   bulletPrefab: {fileID: 8430071279321725386, guid: 7ed4621ce93ddae43adba43f8795ebea, type: 3}
   bulletSpawnPoint: {fileID: 1980790552}
   bulletSpeed: 50
@@ -1389,6 +1391,7 @@ MonoBehaviour:
   targetLayer:
     serializedVersion: 2
     m_Bits: 4294967295
+  playerMeshRenderer: {fileID: 1429826847}
 --- !u!54 &9102701135844288395
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/02_Scripts/BattleSystem/BattleManager.cs
+++ b/Assets/02_Scripts/BattleSystem/BattleManager.cs
@@ -14,7 +14,7 @@ public class BattleManager : MonoBehaviour, IOnEventCallback
 
     Dictionary<int, int> revengeTargetDict = new Dictionary<int, int>();
 
-    int revengeBonusReward = 1;
+    const int REVENGE_BONUS_REWARD = 1;
 
     private void Awake()
     {
@@ -65,7 +65,7 @@ public class BattleManager : MonoBehaviour, IOnEventCallback
         {
             instance.revengeTargetDict[killerActorNumber] = -1;
 
-            ScoreManager.Instance.AddScore(killerActorNumber, victimActorNumber, instance.revengeBonusReward);
+            ScoreManager.Instance.AddScore(killerActorNumber, victimActorNumber, REVENGE_BONUS_REWARD);
         }
 
         // 복수 대상이 아닐 때
@@ -75,11 +75,8 @@ public class BattleManager : MonoBehaviour, IOnEventCallback
         }
 
         // 죽은 플레이어 리스폰 요청
-        PhotonNetwork.RaiseEvent(
-            (byte)RaiseEventCode.RespawnPlayer,
-            null,
-            new RaiseEventOptions { TargetActors = new int[] { victimActorNumber } },
-            SendOptions.SendUnreliable);
+        PlayerSpawnManager.Instance.ExecuteRPC(
+                    RaiseEventCode.RespawnPlayer.ToString(), victimActorNumber);
 
         // 타살일 경우 죽인 자는 죽은 자의 복수 대상으로 갱신
         instance.revengeTargetDict[victimActorNumber] = victimActorNumber != killerActorNumber ? killerActorNumber : instance.revengeTargetDict[victimActorNumber];
@@ -115,7 +112,6 @@ public class BattleManager : MonoBehaviour, IOnEventCallback
 
             BattleUIController.Instance.SetLimitTimeText(seconds);
         }
-
         EndGameByTimeout();
     }
     void CheckTime(int seconds)
@@ -127,7 +123,10 @@ public class BattleManager : MonoBehaviour, IOnEventCallback
         
         if (seconds % 60 == 0 && seconds != 0) // TODO 찬규 : 1분마다 현상금 이벤트 발생
         {
-
+            if (PhotonNetwork.IsMasterClient)
+            {
+                ScoreManager.Instance.SetBountyTarget();
+            }
         }
     }
     void EndGameByTimeout()

--- a/Assets/02_Scripts/BattleSystem/BattleUIController.cs
+++ b/Assets/02_Scripts/BattleSystem/BattleUIController.cs
@@ -4,7 +4,6 @@ using Photon.Realtime;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
-using UnityEngine.Rendering.Universal;
 using UnityEngine.UI;
 
 public class BattleUIController : MonoBehaviour, IOnEventCallback

--- a/Assets/02_Scripts/BattleSystem/PlayerSpawnManager.cs
+++ b/Assets/02_Scripts/BattleSystem/PlayerSpawnManager.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
-public class PlayerSpawnManager : MonoBehaviour, IOnEventCallback
+public class PlayerSpawnManager : MonoBehaviourPun, IOnEventCallback
 {
     public static PlayerSpawnManager Instance { get; private set; } = null;
 
@@ -67,15 +67,6 @@ public class PlayerSpawnManager : MonoBehaviour, IOnEventCallback
         {
             case RaiseEventCode.SpawnPlayer:
                 SpawnPlayer(photonEvent); break;
-
-            case RaiseEventCode.RespawnPlayer:
-                RespawnPlayer(); break;
-
-            case RaiseEventCode.ActivatePlayer:
-                ActivatePlayer(); break;
-
-            case RaiseEventCode.DeactivatePlayer:
-                DeactivatePlayer(); break;
         }
     }
     void SpawnPlayer(EventData photonEvent)
@@ -97,7 +88,8 @@ public class PlayerSpawnManager : MonoBehaviour, IOnEventCallback
 
         ActivatePlayer();
     }
-    void RespawnPlayer()
+    [PunRPC]
+    public void RespawnPlayer()
     {
         Transform spawnPosition = GetRandomTransform();
 
@@ -106,19 +98,37 @@ public class PlayerSpawnManager : MonoBehaviour, IOnEventCallback
 
         ActivatePlayer();
     }
-    void ActivatePlayer()
+    [PunRPC]
+    public void ActivatePlayer()
     {
         // TODO 찬규 : 플레이어 동작 활성화 (currPlayerPhotonView.RPC를 통해 수행해야할듯)
         //currPlayerPhotonView.RPC("")
     }
-    void DeactivatePlayer()
+    [PunRPC]
+    public void DeactivatePlayer()
     {
         // TODO 찬규 : 플레이어 동작 비활성화 (currPlayerPhotonView.RPC를 통해 수행해야할듯)
         
     }
+    public void ExecuteRPC(string functionName, int actorNumber)
+    {
+        photonView.RPC(functionName, PhotonNetwork.CurrentRoom.Players[actorNumber]);
+    }
     public void EndGame()
     {
         DeactivatePlayer();
+    }
+    [PunRPC]
+    public void ActivateBountyTarget()
+    {
+        // TODO 찬규 : 현상금 타겟 지정 이펙트 활성화
+
+    }
+    [PunRPC]
+    public void DeactivateBountyTarget()
+    {
+        // TODO 찬규 : 현상금 타겟 지정 이펙트 비활성화
+
     }
     Transform GetRandomTransform() => spawnPositions[Random.Range(0, spawnPositions.Length)].GetRandomTransform();
     private void OnEnable() => PhotonNetwork.AddCallbackTarget(this);

--- a/Assets/02_Scripts/BattleSystem/RealtimePlayerScoreEntry.cs
+++ b/Assets/02_Scripts/BattleSystem/RealtimePlayerScoreEntry.cs
@@ -1,7 +1,6 @@
 using Photon.Realtime;
 using TMPro;
 using UnityEngine;
-using UnityEngine.SocialPlatforms.Impl;
 
 public class RealtimePlayerScoreEntry : MonoBehaviour
 {

--- a/Assets/02_Scripts/BattleSystem/ScoreManager.cs
+++ b/Assets/02_Scripts/BattleSystem/ScoreManager.cs
@@ -1,13 +1,10 @@
 ﻿using ExitGames.Client.Photon;
-using ExitGames.Client.Photon.StructWrapping;
 using Photon.Pun;
 using Photon.Realtime;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Unity.Mathematics;
 using UnityEngine;
-using VInspector.Libs;
 
 public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
 {
@@ -15,7 +12,9 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
 
     Dictionary<int, PlayerScoreEntryData> playerScoreEntryDict = new Dictionary<int, PlayerScoreEntryData>();
 
-    int killScoreReward = 1;
+    const int KILL_SCORE_REWARD = 1;
+
+    int bountyTargetActorNumber = -1;
 
     bool isFinalMinute = false;
     bool isGameRunning = true;
@@ -38,7 +37,6 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
         }
         isFinalMinute = false;
         isGameRunning = true;
-        killScoreReward = 1;
     }
     public void AddScore(int killerActorNumber, int victimActorNumber, int bonusReward = 0)
     {
@@ -56,9 +54,21 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
         // 자살이 아닌 경우
         if (killerActorNumber != victimActorNumber)
         {
+            if (victimActorNumber == bountyTargetActorNumber)
+            {
+                bonusReward += 3;
+
+                PlayerSpawnManager.Instance.ExecuteRPC(
+                    RaiseEventCode.DeactivateBountyTarget.ToString(), bountyTargetActorNumber);
+
+                bountyTargetActorNumber = -1;
+
+                photonView.RPC("SetBountyTargetActorNumber", RpcTarget.Others, bountyTargetActorNumber);
+            }
+
             playerScoreEntryDict[killerActorNumber].SetScore(
             playerScoreEntryDict[killerActorNumber].Score +
-            (killScoreReward + bonusReward) *
+            (KILL_SCORE_REWARD + bonusReward) *
             (isFinalMinute ? 2 : 1)
             );
 
@@ -87,6 +97,11 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
             playerScoreEntryDict.Values.ToArray(),
             new RaiseEventOptions { Receivers = ReceiverGroup.Others },
             SendOptions.SendReliable);
+    }
+    [PunRPC]
+    public void SetBountyTargetActorNumber(int actorNumber)
+    {
+        bountyTargetActorNumber = actorNumber;
     }
     void HasRankingChanged(int actorNumber)
     {
@@ -164,6 +179,14 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
 
         return scoreList.ToArray();
     }
+    int GetTopScorerActorNumber()
+    {
+        var sortedScores = new List<KeyValuePair<int, PlayerScoreEntryData>>(playerScoreEntryDict);
+
+        sortedScores.Sort((x, y) => y.Value.Score.CompareTo(x.Value.Score));
+
+        return sortedScores[0].Key;
+    }
     public void OnEvent(EventData photonEvent)
     {
         switch ((RaiseEventCode)photonEvent.Code)
@@ -171,6 +194,15 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
             case RaiseEventCode.SaveData:
                 SaveData(photonEvent); break;
         }
+    }
+    public void SetBountyTarget()
+    {
+        bountyTargetActorNumber = GetTopScorerActorNumber();
+
+        photonView.RPC("SetBountyTargetActorNumber", RpcTarget.Others, bountyTargetActorNumber);
+
+        PlayerSpawnManager.Instance.ExecuteRPC(
+            RaiseEventCode.ActivateBountyTarget.ToString(), bountyTargetActorNumber);
     }
     void SaveData(EventData photonEvent)
     {
@@ -180,6 +212,19 @@ public class ScoreManager : MonoBehaviourPunCallbacks, IOnEventCallback
 
             playerScoreEntryDict[playerScoreEntryData.ActorNumber] = playerScoreEntryData;
     }
+
+    //public override void OnEnable()
+    //{
+    //    base.OnEnable();
+
+    //    PhotonNetwork.AddCallbackTarget(this);
+    //}
+    //public override void OnDisable()
+    //{
+    //    base.OnDisable();
+
+    //    PhotonNetwork.AddCallbackTarget(this);
+    //}
 }
 
 [Serializable]
@@ -190,7 +235,6 @@ public class PlayerScoreEntryData
     public int Assist { get; private set; }
     public int Score { get; private set; }
     public int ActorNumber { get; private set; }
-
     public PlayerScoreEntryData(int kill, int death, int assist, int score, int actorNumber)
     {
         Kill = kill;

--- a/Assets/02_Scripts/Manager/PlayerManager.cs
+++ b/Assets/02_Scripts/Manager/PlayerManager.cs
@@ -19,6 +19,9 @@ public class PlayerManager : PlayerStatController
     private LayerMask targetLayer;
     private Animator anim;
     private Vector3 targetPosition = Vector3.zero;
+
+    [SerializeField] Transform playerMeshRenderer;
+
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
@@ -100,13 +103,11 @@ public class PlayerManager : PlayerStatController
             
             targetPosition = camTransform.position + camTransform.forward * 10f;
         }
-
-        
         targetAim = targetPosition;
         targetAim.y = transform.position.y;
         aimDir = (targetAim - transform.position).normalized;
 
-       
-        transform.forward = Vector3.Lerp(transform.forward, aimDir, Time.deltaTime * 30f);
+        playerMeshRenderer.forward = Vector3.Lerp(playerMeshRenderer.forward, aimDir, Time.deltaTime * 30f);
+        //transform.forward = Vector3.Lerp(transform.forward, aimDir, Time.deltaTime * 30f);
     }
 }

--- a/Assets/02_Scripts/RaiseEventCode.cs
+++ b/Assets/02_Scripts/RaiseEventCode.cs
@@ -15,6 +15,8 @@ public enum RaiseEventCode
     RespawnPlayer = 41,
     ActivatePlayer = 42,
     DeactivatePlayer = 43,
+    ActivateBountyTarget = 44,
+    DeactivateBountyTarget = 45,
 
     #endregion
 
@@ -26,6 +28,7 @@ public enum RaiseEventCode
     UpdateRank = 53,
     UpdateRealtime = 54,
     ResetScoreboard = 55,
+    
 
     #endregion
 }

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -41,6 +41,12 @@ MonoBehaviour:
   - RespawnSpaceship
   - FireBullet_RPC
   - ApplyUpwardForce_RPC
+  - ActivateBountyTarget
+  - ActivatePlayer
+  - DeactivateBountyTarget
+  - DeactivatePlayer
+  - RespawnPlayer
+  - SetBountyTargetActorNumber
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 0


### PR DESCRIPTION
수정한 스크립트 : ScoreManager - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

현상금 대상인 유저 처치 시 3점을 추가로 지급

photonView.RPC("SetBountyTargetActorNumber", RpcTarget.Others, bountyTargetActorNumber);를 통해
RPC 함수를 호출한다


수정한 스크립트 : PlayerSpawnManager - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

MonoBehaviourPun을 상속받고 photonView.RPC 함수 호출을 한다
이를 통해 PhotonNetwork.RaiseEvent의 부담을 줄였다


주의 : PunRPC로 인한 PhotonServerSetting 글로벌 파일 변경됨

지식: MonoBehaviourPunCallbacks는 PhotonView도 가지고 있으며,
         PhotonNetwork.AddCallbackTarget(this);를 자동으로 처리해준다