### PR TITLE
ScoreManager 현상금 점수 보너스 구현

### DIFF
--- a/Assets/02_Scripts/Manager/PlayerManager.cs
+++ b/Assets/02_Scripts/Manager/PlayerManager.cs
@@ -19,9 +19,6 @@ public class PlayerManager : PlayerStatController
     private LayerMask targetLayer;
     private Animator anim;
     private Vector3 targetPosition = Vector3.zero;
-
-    [SerializeField] Transform playerMeshRenderer;
-
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
@@ -103,11 +100,13 @@ public class PlayerManager : PlayerStatController
             
             targetPosition = camTransform.position + camTransform.forward * 10f;
         }
+
+        
         targetAim = targetPosition;
         targetAim.y = transform.position.y;
         aimDir = (targetAim - transform.position).normalized;
 
-        playerMeshRenderer.forward = Vector3.Lerp(playerMeshRenderer.forward, aimDir, Time.deltaTime * 30f);
-        //transform.forward = Vector3.Lerp(transform.forward, aimDir, Time.deltaTime * 30f);
+       
+        transform.forward = Vector3.Lerp(transform.forward, aimDir, Time.deltaTime * 30f);
     }
 }


### PR DESCRIPTION
수정한 스크립트 : ScoreManager - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

현상금 대상인 유저 처치 시 3점을 추가로 지급

photonView.RPC("SetBountyTargetActorNumber", RpcTarget.Others, bountyTargetActorNumber);를 통해
RPC 함수를 호출한다

수정한 스크립트 : PlayerSpawnManager - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

MonoBehaviourPun을 상속받고 photonView.RPC 함수 호출을 한다
이를 통해 PhotonNetwork.RaiseEvent의 부담을 줄였다

주의 : PunRPC로 인한 PhotonServerSetting 글로벌 파일 변경됨,
          플레이어 매니저 백업된 내용으로 커밋

지식: MonoBehaviourPunCallbacks는 PhotonView도 가지고 있으며,
PhotonNetwork.AddCallbackTarget(this);를 자동으로 처리해준다